### PR TITLE
.rel_directory in serializers lists all rels.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Serializers have helpers to add links between resources, based upon registered e
 class UserSerializer < Bridger::Serializer
   schema do
     # link to self (current URL)
-    self_link
+    rel :user, id: item.id, as: :self
     # link to another endpoint
     # will only be included if current credentials have permissions to other endpoint
     rel :update_user, user_id: item.id

--- a/lib/bridger/serializer.rb
+++ b/lib/bridger/serializer.rb
@@ -40,6 +40,12 @@ module Bridger
       link name, args
     end
 
+    def rel_directory
+      h.endpoints.each do |endpoint|
+        rel endpoint.name
+      end
+    end
+
     def self_link
       link :self, href: h.current_url
     end

--- a/spec/support/test_api.rb
+++ b/spec/support/test_api.rb
@@ -85,11 +85,7 @@ end
 # Serializers turn the result of actions into JSON structures
 class RootSerializer < Bridger::Serializer
   schema do
-    self_link
-    rel :status
-    rel :user
-    rel :users
-    rel :create_user
+    rel_directory
 
     link("btc:schemas", href: url("/schemas"))
 


### PR DESCRIPTION
## What

Add `.rel_directory` serializer helper. It lists all relations (endpoints), as an alternative to manually calling `.rel(rel_name)` for each.

## Why

So we can have root resources that automatically list all available endpoints (subject to current permissions).

```ruby
class RootSerializer < Bridger::Serializer
  schema do
    rel_directory

    # Instead of:
    # rel :users 
    # rel :user 
    # rel :create_user
    # rel :things
    # ...etc

    property :welcome, "Welcome to this API"
  end
end

```