### PR TITLE
Rename Action.query => .query_schema and .payload => .payload_schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ An action defines payload parameters, runs them through a method and returns a d
 
 ```ruby
 class CreateUser < Bridger::Action
-  payload do
+  payload_schema do
     field(:name).type(:string).required
   end
 
@@ -77,11 +77,11 @@ Optionally, actions can also define a _query schema_, ie. parameters passed sepa
 
 ```ruby
 class UpdateUser < Bridger::Action
-  query do
+  query_schema do
     field(:user_id).type(:integer).present
   end
 
-  payload do
+  payload_schema do
     field(:name).type(:string).required
   end
 

--- a/lib/bridger/action.rb
+++ b/lib/bridger/action.rb
@@ -17,11 +17,11 @@ module Bridger
       new(*args).run!
     end
 
-    def self.payload(*args, &block)
+    def self.payload_schema(*args, &block)
       self.schema *args, &block
     end
 
-    def self.query(*args, &block)
+    def self.query_schema(*args, &block)
       self.schema *(args.unshift(:query)), &block
     end
 
@@ -62,15 +62,15 @@ module Bridger
     end
 
     def payload_validator
-      @payload_validator ||= self.class.payload.resolve(_payload)
+      @payload_validator ||= self.class.payload_schema.resolve(_payload)
     end
 
     def query_validator
-      @query_validator ||= self.class.query.resolve(_query)
+      @query_validator ||= self.class.query_schema.resolve(_query)
     end
 
     def schema
-      self.class.payload
+      self.class.payload_schema
     end
 
     def map(hash)

--- a/lib/bridger/endpoint.rb
+++ b/lib/bridger/endpoint.rb
@@ -45,11 +45,11 @@ module Bridger
     end
 
     def query_schema
-      action.query
+      action.query_schema
     end
 
     def payload_schema
-      action.payload
+      action.payload_schema
     end
 
     def output_schema
@@ -70,7 +70,7 @@ module Bridger
     attr_reader :authorizer
 
     def query_keys
-      mutating? ? [] : action.query.structure.keys
+      mutating? ? [] : action.query_schema.structure.keys
     end
 
     def mutating?

--- a/lib/sinatra/bridger.rb
+++ b/lib/sinatra/bridger.rb
@@ -1,6 +1,7 @@
 require 'json'
 require 'bridger'
 require 'bridger/default_serializers'
+require 'parametric/struct'
 
 module Sinatra
   module Bridger

--- a/spec/endpoint_spec.rb
+++ b/spec/endpoint_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Bridger::Endpoint do
   let(:authorizer) { double('Authorizer') }
   let(:action) do
     Class.new(Bridger::Action) do
-      query do
+      query_schema do
         field(:product_id).type(:string).present
         field(:q).type(:string)
       end

--- a/spec/support/test_api.rb
+++ b/spec/support/test_api.rb
@@ -12,7 +12,7 @@ Thing = Struct.new(:name)
 # their `#run!` method returns a data object (ex. a model) then passed to the serializer
 
 class CreateUser < Bridger::Action
-  payload do
+  payload_schema do
     field(:name).type(:string).required
     field(:age).type(:integer).required
   end
@@ -29,7 +29,7 @@ class CreateUser < Bridger::Action
 end
 
 class ShowUser < Bridger::Action
-  query do
+  query_schema do
     field(:user_id).type(:string).required
   end
 
@@ -40,7 +40,7 @@ class ShowUser < Bridger::Action
 end
 
 class ListUserThings < Bridger::Action
-  query do
+  query_schema do
     field(:user_id).type(:string).required
     field(:page).type(:integer).default(1)
   end
@@ -55,7 +55,7 @@ class ListUserThings < Bridger::Action
 end
 
 class DeleteUser < Bridger::Action
-  query do
+  query_schema do
     field(:user_id).type(:string).required
   end
 
@@ -66,7 +66,7 @@ class DeleteUser < Bridger::Action
 end
 
 class ListUsers < Bridger::Action
-  query do
+  query_schema do
     field(:q).type(:string)
   end
 


### PR DESCRIPTION
So that it’s distinct from internal #query and #payload hashes, and so that the action API is simpler and we can implement custom instance-only actions if we need to

```ruby
# A custom action that implements the entire Action API as instance methods only.
class CustomAction
  def query_schema
    Parametric::Schema.new do
      field(:id)
    end
  end

  def payload_schema
    Parametric::Schema.new # etc
  end

  def run(query: {}, payload: {}, auth: nil)
    # do something
  end
end
```