### PR TITLE
Rename Endpoints to Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,13 +122,13 @@ end
 user_data = UserSerializer.new(user, h: request_helper, auth: auth).to_hash
 ```
 
-### Endpoints
+### Service endpoints
 
-An endpoint combines auth, action and serializer into a callable object that fulfills an entire API request (albeit being framework agnostic).
+A service is a collection of _endpoints_. An endpoint combines auth, action and serializer into a callable object that fulfills an entire API request (albeit being framework agnostic).
 Endpoints include access scopes and pass information to serializers so they can generate (or not) links to other endpoints, based on permissions.
 
 ```ruby
-Bridger::Endpoints.instance do
+Bridger::Service.instance do
   endpoint(:root, :get, '/?',
     title: "API root",
     scope: 'all.me',
@@ -153,7 +153,7 @@ end
 Endpoints can be invoked on their own.
 
 ```ruby
-endpoint = Bridger::Endpoints.instance[:create_user]
+endpoint = Bridger::Service.instance[:create_user]
 user_data = endpoint.run!(
   # payload is user-provided data to be passed to action
   payload: {name: "Joe"},
@@ -202,7 +202,7 @@ require 'sinatra/base'
 
 class API < Sinatra::Base
   extend Sinatra::Bridger
-  bridge Bridger::Endpoints.instance, logger: Logger.new(STDOUT)
+  bridge Bridger::Service.instance, logger: Logger.new(STDOUT)
 end
 ```
 
@@ -218,7 +218,7 @@ These can be exposed as JSON endpoints under a custom path in your API, with
 ```ruby
 class API < Sinatra::Base
   extend Sinatra::Bridger
-  bridge  Bridger::Endpoints.instance, schemas: '/schemas'
+  bridge  Bridger::Service.instance, schemas: '/schemas'
 end
 ```
 
@@ -247,7 +247,7 @@ Sometimes you'll want to authorize based on ownership. For example, I can only u
 For that you can define guard blocks that run at a specific branch of an endpoint's scope:
 
 ```ruby
-Bridger::Endpoints.instance do
+Bridger::Service.instance do
   # run this block when hitting an endpoint with `all.users.update` scope
   # and verify that targeted user is present in my access token info
   authorize "all.users.update" do |scope, auth, params|

--- a/lib/bridger.rb
+++ b/lib/bridger.rb
@@ -4,6 +4,6 @@ module Bridger
   # Your code goes here...
 end
 require 'bridger/auth'
-require 'bridger/endpoints'
+require 'bridger/service'
 require 'bridger/action'
 require 'bridger/serializer'

--- a/lib/bridger/serializer.rb
+++ b/lib/bridger/serializer.rb
@@ -20,7 +20,7 @@ module Bridger
       as = opts.delete(:as)
       always = opts.delete(:always)
 
-      endpoint = h.endpoints[name]
+      endpoint = h.service[name]
       raise "no endpoint defined for name ':#{name}'" unless endpoint
 
       return unless always || endpoint.authorized?(auth, opts)
@@ -41,7 +41,7 @@ module Bridger
     end
 
     def rel_directory
-      h.endpoints.each do |endpoint|
+      h.service.each do |endpoint|
         rel endpoint.name
       end
     end

--- a/lib/bridger/service.rb
+++ b/lib/bridger/service.rb
@@ -1,7 +1,7 @@
 require "bridger/authorizers"
 
 module Bridger
-  class Endpoints
+  class Service
     def self.instance
       @instance ||= new
     end

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
-require "bridger/endpoints"
+require "bridger/service"
 
-RSpec.describe Bridger::Endpoints do
+RSpec.describe Bridger::Service do
   Action = Class.new do
     def initialize(result)
       @result = result

--- a/spec/support/test_api.rb
+++ b/spec/support/test_api.rb
@@ -161,7 +161,7 @@ Bridger::Auth.config do |c|
 end
 
 # Your API's endpoints. Each combines an action, serializer, some metadata and a permissions scope.
-Bridger::Endpoints.instance.build do
+Bridger::Service.instance.build do
   endpoint(:root, :get, "/?",
     title: "API root",
     scope: "api.me",
@@ -220,6 +220,6 @@ LOGGER = Logger.new(STDOUT)
 #
 class TestAPI < Sinatra::Base
   extend Sinatra::Bridger
-  bridge Bridger::Endpoints.instance, schemas: '/schemas', logger: LOGGER
+  bridge Bridger::Service.instance, schemas: '/schemas', logger: LOGGER
 end
 


### PR DESCRIPTION
Rename `Bridger::Endpoints` to `Bridger::Service`. A service is a collection of endpoints.
Better naming, and opens the door to supporting multiple services per process if we ever need to.