### PR TITLE
Make JSON Schema props include any custom meta data keys

### DIFF
--- a/lib/bridger/json_schema_generator.rb
+++ b/lib/bridger/json_schema_generator.rb
@@ -1,5 +1,7 @@
 module Bridger
   class JsonSchemaGenerator
+    KNOWN_ATTR_FIELDS = %i[type title description default example options required structure].freeze
+
     BASE = {
       '$schema' => 'http://json-schema.org/draft-04/schema#',
       'type' => 'object'
@@ -45,6 +47,9 @@ module Bridger
             base.merge!(process(attrs[:structure]))
           end
         end
+
+        meta_data = attrs.each.with_object({}) { |(k, v), ret| ret[k.to_s] = v unless KNOWN_ATTR_FIELDS.include?(k) }
+        base.merge!(meta_data)
 
         node['properties'][k.to_s] = base
         node['required'] = reqs if reqs.any?

--- a/spec/json_schema_generator_spec.rb
+++ b/spec/json_schema_generator_spec.rb
@@ -4,11 +4,11 @@ require 'bridger/json_schema_generator'
 RSpec.describe Bridger::JsonSchemaGenerator do
   let(:s1) do
     Parametric::Schema.new do
-      field(:name).type(:string).meta(title: 'Some title').present
+      field(:name).type(:string).meta(title: 'Some title', tags: ['t1', 't2']).present
       field(:age).type(:integer).required.default(41)
-      field(:options).type(:string).options(['A', 'B'])
+      field(:letters).type(:string).options(['A', 'B'])
       field(:friends).type(:array).schema do
-        field(:name).type(:string).meta(title: 'Some other title', description: 'Some description').present
+        field(:name).type(:string).meta(title: 'Some other title', description: 'Some description', foo: 'bar').present
       end
       field(:company).type(:object).schema do
         field(:name).type(:string).present
@@ -23,10 +23,11 @@ RSpec.describe Bridger::JsonSchemaGenerator do
     result['properties'].tap do |props|
       expect(props['name']['type']).to eq 'string'
       expect(props['name']['title']).to eq 'Some title'
+      expect(props['name']['tags']).to eq ['t1', 't2']
       expect(props['age']['type']).to eq 'integer'
       expect(props['age']['default']).to eq 41
-      expect(props['options']['type']).to eq 'string'
-      expect(props['options']['enum']).to eq ['A', 'B']
+      expect(props['letters']['type']).to eq 'string'
+      expect(props['letters']['enum']).to eq ['A', 'B']
       expect(props['company']['type']).to eq 'object'
       props['company']['properties'].tap do |company|
         expect(company['name']['type']).to eq 'string'
@@ -37,6 +38,7 @@ RSpec.describe Bridger::JsonSchemaGenerator do
       props.dig('friends', 'items', 'properties', 'name').tap do |name|
         expect(name['title']).to eq 'Some other title'
         expect(name['description']).to eq 'Some description'
+        expect(name['foo']).to eq 'bar'
       end
     end
     expect(result['required']).to eq ['name', 'age']


### PR DESCRIPTION
So JSON Schemas always include all meta data added to fields.