### PR TITLE
Wildcard scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,13 @@ A request's token scope is compared with a given endpoint's token to check acces
 * `all.accounts` does NOT have access to `all.users`
 * `all.accounts` does NOT have access to `all.users.create`
 
+_Wildcard_ scopes are possible using the special character `*` as one or more segments in a scope.
+For example:
+
+* `all.*.create` has access to `all.accounts.create` or `all.photos.create`
+* `all.*.create` has access to `all.accounts.*`
+* `all.*.create.*` does not have access to `all.accounts.create` (because it's more specific).
+
 Sometimes you'll want to authorize based on ownership. For example, I can only update a user whose ID is included in my credentials.
 For that you can define guard blocks that run at a specific branch of an endpoint's scope:
 

--- a/lib/bridger/scopes.rb
+++ b/lib/bridger/scopes.rb
@@ -60,6 +60,8 @@ module Bridger
 
     class Scope
       SEP = '.'.freeze
+      WILDCARD = '*'.freeze
+
       include Comparable
 
       def initialize(sc)
@@ -79,17 +81,37 @@ module Bridger
       end
 
       def <=>(another_scope)
-        diff = segments - another_scope.segments
+        return -1 if segments.size > another_scope.segments.size
+
+        other_segments = homologate_other_segments_for_comparison(another_scope)
+
+        diff = segments - other_segments
         if diff.size == 0
           1
         else
+          diff = diff.uniq
+          if diff.size == 1 && diff.first == WILDCARD
+            1
+          else
           -1
+          end
         end
       end
 
       protected
 
       attr_reader :segments
+
+      private
+
+      def homologate_other_segments_for_comparison(another_scope)
+        other_segments = another_scope.segments[0...segments.size].map.with_index do |s, idx|
+          s == WILDCARD ? segments[idx] : s
+        end
+        other_segments += another_scope.segments[segments.size..-1] if another_scope.segments.size > segments.size
+
+        other_segments
+      end
     end
 
     class Aliases

--- a/spec/scopes_spec.rb
+++ b/spec/scopes_spec.rb
@@ -3,7 +3,7 @@ require 'bridger/scopes'
 
 RSpec.describe Bridger::Scopes do
   describe Bridger::Scopes::Scope do
-    it do
+    it 'compares scopes' do
       more_specific_scope =  described_class.new("btc.account.shops.mine.update")
       less_specific_scope =  described_class.new("btc.account.shops.mine")
       different_scope =  described_class.new("btc.foo.shops.mine")
@@ -16,6 +16,18 @@ RSpec.describe Bridger::Scopes do
       expect(less_specific_scope.can?(different_scope)).to be false
       expect(different_scope.can?(less_specific_scope)).to be false
       expect(different_scope.can?(more_specific_scope)).to be false
+    end
+
+    it 'allows wildcards' do
+      expect(first_one_wins('a.*.c', 'a.b.c')).to be true
+      expect(first_one_wins('a.*.c', 'a.b.z')).to be false
+      expect(first_one_wins('a.*.c', 'a.z.c.e')).to be true
+      expect(first_one_wins('a.*.c', 'a.z.*')).to be true
+      expect(first_one_wins('a.*.c', 'a.z.*.x')).to be true
+      expect(first_one_wins('a.*.c.*', 'a.z.c')).to be false
+      expect(first_one_wins('a.*.c.*', 'a.b.c.d')).to be true
+      expect(first_one_wins('a.*.c.*', 'a.b.c.*')).to be true
+      expect(first_one_wins('a.*.c.*', 'a.*.c.*')).to be true
     end
   end
 
@@ -75,4 +87,15 @@ RSpec.describe Bridger::Scopes do
       expect(user_scopes.to_a).to eq ["aa.aa", "bb.bb"]
     end
   end
+
+  private
+
+  def scope(exp)
+    described_class.new(exp)
+  end
+
+  def first_one_wins(exp1, exp2)
+    scope(exp1).can?(scope(exp2))
+  end
+
 end

--- a/spec/scopes_spec.rb
+++ b/spec/scopes_spec.rb
@@ -97,5 +97,4 @@ RSpec.describe Bridger::Scopes do
   def first_one_wins(exp1, exp2)
     scope(exp1).can?(scope(exp2))
   end
-
 end


### PR DESCRIPTION
Make _wildcard_ scopes possible by using the special character `*` as one or more segments in a scope.

For example:

* `all.*.create` has access to `all.accounts.create` or `all.photos.create`
* `all.*.create` has access to `all.accounts.*`
* `all.*.create.*` does not have access to `all.accounts.create` (because it's more specific).
