### PR TITLE
Scope Tree and other tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,54 @@ SCOPES.all.*.read # Ok
 SCOPES.all.*.update # raises NoMethodError because not all children of `all.*` support `update`
 ```
 
+Hierarchies can also be defined using the > operator:
+This can help avoid typos.
+
+```ruby
+SCOPES = Bridger::Scopes::Tree.new('bootic') do |bootic|
+  api = 'api'
+  products = 'products'
+  orders = 'orders'
+  own = 'own'
+  all = 'all'
+  read = 'read'
+
+  bootic > api > products > own > read
+  bootic > api > products > all > read
+  bootic > api > orders > own > read
+end
+```
+
+Block notation can be used where it makes sense:
+
+```ruby
+SCOPES = Bridger::Scopes::Tree.new('bootic') do |bootic|
+  bootic.api.products do |n|
+    n.own do |n|
+      n.read
+      n.write
+      n > 'list' # use `>` to append variables or constants
+    end
+  end
+end
+```
+
+Block notation also works without explicit node argument (but can't access outer variables):
+
+```ruby
+SCOPES = Bridger::Scopes::Tree.new('bootic') do
+  api.products do
+    own do
+      read
+      write
+    end
+    all do
+      read
+    end
+  end
+end
+```
+
 ## Testing
 
 Bridger attempts to make testing hypermedia APIs easier.

--- a/README.md
+++ b/README.md
@@ -384,6 +384,15 @@ SCOPES = Bridger::Scopes::Tree.new('bootic') do
 end
 ```
 
+Scope trees also work with scope aliases.
+
+```ruby
+config.aliases = {
+  'admin' => [SCOPES.api.products.own, SCOPES.api.orders.own, SCOPES.api.all.read],
+  'god' => [SCOPES.api]
+}
+```
+
 ## Testing
 
 Bridger attempts to make testing hypermedia APIs easier.

--- a/lib/bridger/auth.rb
+++ b/lib/bridger/auth.rb
@@ -112,10 +112,13 @@ module Bridger
 
     attr_reader :access_token, :claims, :scopes
 
+    # @option access_token [String] the access token. Default: nil
+    # @option claims [Hash] the claims of the access token.
+    # @option aliases [Scopes::Aliases]
     def initialize(access_token: nil, claims: {}, aliases: self.config.aliases)
       @access_token = access_token
       @claims = claims
-      @scopes = Scopes.new(aliases.map(@claims["scopes"]))
+      @scopes = aliases.map(@claims['scopes'])
     end
 
     def authorized?(scope)

--- a/lib/bridger/auth.rb
+++ b/lib/bridger/auth.rb
@@ -87,17 +87,22 @@ module Bridger
       access_token = config.authenticator.call(request)
 
       raise MissingAccessTokenError, "missing access token with #{config.authenticator}" unless access_token
+
+      resolve_access_token(access_token, config)
+    rescue StandardError => e
+      config.logger.error "#{e.class.name}: #{e.message}"
+      raise
+    end
+
+    def self.resolve_access_token(access_token, config = self.config)
       claims = config.token_store.get(access_token)
-      raise InvalidAccessTokenError, "unknown access token" unless claims
+      raise InvalidAccessTokenError, 'unknown access token' unless claims
 
       new(
         access_token: access_token,
         claims: claims,
         aliases: config.aliases,
       )
-    rescue StandardError => e
-      config.logger.error "#{e.class.name}: #{e.message}"
-      raise
     end
 
     def self.config(&block)

--- a/lib/bridger/authorizers.rb
+++ b/lib/bridger/authorizers.rb
@@ -19,9 +19,9 @@ module Bridger
       end
 
       def at(scope, &block)
-        segments = parse_segments(scope)
+        scope = Bridger::Scopes::Scope.wrap(scope)
 
-        branch = segments.reduce(self) do |b, segment|
+        branch = scope.to_a.reduce(self) do |b, segment|
           br = branches[segment]
           if br # exists
             br
@@ -34,9 +34,10 @@ module Bridger
       end
 
       def authorized?(scope, *args)
+        scope = Bridger::Scopes::Scope.wrap(scope)
         return false unless checks.all?{|ch| ch.call(scope, *args) }
 
-        segments = parse_segments(scope)
+        segments = scope.to_a
         segment = segments.shift
         branch = branches[segment]
 
@@ -46,11 +47,8 @@ module Bridger
       end
 
       private
-      attr_reader :branches, :checks
 
-      def parse_segments(segments)
-        segments.is_a?(String) ? segments.split('.') : segments.to_a
-      end
+      attr_reader :branches, :checks
     end
   end
 end

--- a/lib/bridger/endpoint.rb
+++ b/lib/bridger/endpoint.rb
@@ -15,13 +15,7 @@ module Bridger
       @verb = verb.to_sym
       @path = path
       @title = title
-      @scope = if scope.respond_to?(:to_scope)
-        scope.to_scope
-      elsif scope.is_a?(String) || scope.is_a?(Array)
-        Bridger::Scopes::Scope.new(scope)
-      else
-        nil
-      end
+      @scope = scope ? Bridger::Scopes::Scope.wrap(scope) : nil
       @authorizer = authorizer
       @action = action || Bridger::Action
       @serializer = serializer

--- a/lib/bridger/endpoint.rb
+++ b/lib/bridger/endpoint.rb
@@ -15,7 +15,13 @@ module Bridger
       @verb = verb.to_sym
       @path = path
       @title = title
-      @scope = scope ? Bridger::Scopes::Scope.new(scope) : nil
+      @scope = if scope.respond_to?(:to_scope)
+        scope.to_scope
+      elsif scope.is_a?(String) || scope.is_a?(Array)
+        Bridger::Scopes::Scope.new(scope)
+      else
+        nil
+      end
       @authorizer = authorizer
       @action = action || Bridger::Action
       @serializer = serializer

--- a/lib/bridger/scopes.rb
+++ b/lib/bridger/scopes.rb
@@ -2,6 +2,7 @@
 
 require 'bridger/scopes/scope'
 require 'bridger/scopes/aliases'
+require 'bridger/scopes/tree'
 
 module Bridger
   class Scopes

--- a/lib/bridger/scopes.rb
+++ b/lib/bridger/scopes.rb
@@ -110,9 +110,11 @@ module Bridger
       end
 
       def map(scopes)
-        Array(scopes.to_a).reduce([]){|memo, sc|
+        scpes = Array(scopes.to_a).reduce([]){|memo, sc|
           memo + Array(@mapping.fetch(sc, sc))
         }.uniq
+
+        Scopes.wrap(scpes)
       end
     end
   end

--- a/lib/bridger/scopes.rb
+++ b/lib/bridger/scopes.rb
@@ -49,6 +49,10 @@ module Bridger
       hit ? 1 : -1
     end
 
+    def inspect
+      %(<#{self.class.name}##{object_id} [#{to_s}]>)
+    end
+
     def to_s
       @to_s ||= scopes.join(', ')
     end

--- a/lib/bridger/scopes.rb
+++ b/lib/bridger/scopes.rb
@@ -24,7 +24,7 @@ module Bridger
 
     def initialize(scopes)
       @scopes = scopes.map{|sc|
-        sc.is_a?(Scope) ? sc : Scope.new(sc)
+        sc.respond_to?(:to_scope) ? sc.to_scope : Scope.new(sc)
       }.sort{|a,b| b <=> a}
     end
 

--- a/lib/bridger/scopes.rb
+++ b/lib/bridger/scopes.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'bridger/scopes/scope'
+require 'bridger/scopes/aliases'
+
 module Bridger
   class Scopes
     include Comparable
@@ -64,96 +67,5 @@ module Bridger
     protected
 
     attr_reader :scopes
-
-    private
-
-    class Scope
-      SEP = '.'.freeze
-      WILDCARD = '*'.freeze
-
-      include Comparable
-
-      def initialize(sc)
-        @segments = sc.is_a?(Array) ? sc : sc.split(SEP)
-      end
-
-      def to_s
-        segments.join(SEP)
-      end
-
-      def to_a
-        segments.dup
-      end
-
-      def can?(another_scope)
-        self >= another_scope
-      end
-
-      def <=>(another_scope)
-        a, b = segments, another_scope.segments
-        return -1 if a.size > b.size
-
-        a = equalize(a, b)
-        b = equalize(b, a)
-        diff = a - b
-        diff.size == 0 ? 1 : -1
-      end
-
-      protected
-
-      attr_reader :segments
-
-      private
-
-      def equalize(a, b)
-        shortest = [a.size, b.size].min
-        0.upto(shortest - 1).map { |i| a[i] == WILDCARD ? b[i] : a[i] }
-      end
-    end
-
-    # Aliases for scopes
-    # Example:
-    #  aliases = Aliases.new('read' => ['read:users'])
-    #  aliases.map('read') # => ['read:users']
-    #  aliases.map('read:users') # => ['read:users']
-    class Aliases
-      # @param [Hash<String, Array<String>>] scope mapping
-      def initialize(mapping = {})
-        @mapping = mapping
-      end
-
-      # Map scopes to aliases
-      # Example:
-      # aliases = Aliases.new('read' => ['read:users'])
-      # aliases.map('read') # => ['read:users']
-      #
-      # @param [Array<String>] scopes
-      # @return [Scopes]
-      def map(scopes)
-        scpes = Array(scopes.to_a).reduce([]){|memo, sc|
-          memo + Array(@mapping.fetch(sc, sc))
-        }.uniq
-
-        Scopes.wrap(scpes)
-      end
-
-      # Expand scopes with aliases, including original scopes
-      # Example:
-      #
-      # aliases = Aliases.new('read' => 'read:users')
-      # aliases.expand('read') # => Scopes['read', 'read:users']
-      #
-      # @param [Array<String>] scopes
-      # @return [Scopes]
-      def expand(scopes)
-        scopes = Array(scopes.to_a)
-        registered_scopes = scopes.filter { |sc| @mapping.key?(sc) }
-        result = registered_scopes + registered_scopes.reduce([]) { |memo, sc|
-          memo + Array(@mapping.fetch(sc))
-        }.uniq
-
-        Scopes.wrap(result)
-      end
-    end
   end
 end

--- a/lib/bridger/scopes.rb
+++ b/lib/bridger/scopes.rb
@@ -9,29 +9,21 @@ module Bridger
     include Comparable
 
     def self.wrap(sc)
-      case sc
-      when String, Scope
-        new([sc])
-      when Symbol
-        new([sc.to_s])
-      when Array
-        new(sc)
-      when Scopes
+      if sc.is_a?(Scopes)
         sc
       else
-        raise ArgumentError, "Can't compare #{sc.inspect} with #{self.name}"
+        new(sc)
       end
     end
 
+    # @param scopes [Array<Scope, String>]
     def initialize(scopes)
-      @scopes = scopes.map{|sc|
-        sc.respond_to?(:to_scope) ? sc.to_scope : Scope.new(sc)
-      }.sort{|a,b| b <=> a}
+      @scopes = [scopes].flatten.map { |s| Scope.wrap(s) }.sort{ |a, b| b <=> a}
     end
 
     def resolve(scope)
-      sc = scope.is_a?(String) ? Scope.new(scope) : scope
-      scopes.find{|s| s >= sc }
+      sc = Scope.wrap(scope)
+      scopes.find { |s| s >= sc }
     end
 
     def any?(&block)

--- a/lib/bridger/scopes.rb
+++ b/lib/bridger/scopes.rb
@@ -56,6 +56,7 @@ module Bridger
     end
 
     protected
+
     attr_reader :scopes
 
     private
@@ -104,7 +105,13 @@ module Bridger
       end
     end
 
+    # Aliases for scopes
+    # Example:
+    #  aliases = Aliases.new('read' => ['read:users'])
+    #  aliases.map('read') # => ['read:users']
+    #  aliases.map('read:users') # => ['read:users']
     class Aliases
+      # @param [Hash<String, Array<String>>] scope mapping
       def initialize(mapping = {})
         @mapping = mapping
       end
@@ -115,6 +122,24 @@ module Bridger
         }.uniq
 
         Scopes.wrap(scpes)
+      end
+
+      # Expand scopes with aliases, including original scopes
+      # Example:
+      #
+      # aliases = Aliases.new('read' => 'read:users')
+      # aliases.expand('read') # => Scopes['read', 'read:users']
+      #
+      # @param [Array<String>] scopes
+      # @return [Scopes]
+      def expand(scopes)
+        scopes = Array(scopes.to_a)
+        registered_scopes = scopes.filter { |sc| @mapping.key?(sc) }
+        result = registered_scopes + registered_scopes.reduce([]) { |memo, sc|
+          memo + Array(@mapping.fetch(sc))
+        }.uniq
+
+        Scopes.wrap(result)
       end
     end
   end

--- a/lib/bridger/scopes.rb
+++ b/lib/bridger/scopes.rb
@@ -116,6 +116,13 @@ module Bridger
         @mapping = mapping
       end
 
+      # Map scopes to aliases
+      # Example:
+      # aliases = Aliases.new('read' => ['read:users'])
+      # aliases.map('read') # => ['read:users']
+      #
+      # @param [Array<String>] scopes
+      # @return [Scopes]
       def map(scopes)
         scpes = Array(scopes.to_a).reduce([]){|memo, sc|
           memo + Array(@mapping.fetch(sc, sc))

--- a/lib/bridger/scopes.rb
+++ b/lib/bridger/scopes.rb
@@ -8,6 +8,8 @@ module Bridger
       case sc
       when String, Scope
         new([sc])
+      when Symbol
+        new([sc.to_s])
       when Array
         new(sc)
       when Scopes

--- a/lib/bridger/scopes/aliases.rb
+++ b/lib/bridger/scopes/aliases.rb
@@ -4,9 +4,9 @@ module Bridger
   class Scopes
     # Aliases for scopes
     # Example:
-    #  aliases = Aliases.new('read' => ['read:users'])
-    #  aliases.map('read') # => ['read:users']
-    #  aliases.map('read:users') # => ['read:users']
+    #  aliases = Aliases.new('read' => ['read.users'])
+    #  aliases.map('read') # => ['read.users']
+    #  aliases.map('read:users') # => ['read.users']
     class Aliases
       # @param [Hash<String, Array<String>>] scope mapping
       def initialize(mapping = {})
@@ -15,8 +15,8 @@ module Bridger
 
       # Map scopes to aliases
       # Example:
-      # aliases = Aliases.new('read' => ['read:users'])
-      # aliases.map('read') # => ['read:users']
+      # aliases = Aliases.new('read' => ['read.users'])
+      # aliases.map('read') # => ['read.users']
       #
       # @param [Array<String>] scopes
       # @return [Scopes]
@@ -31,8 +31,8 @@ module Bridger
       # Expand scopes with aliases, including original scopes
       # Example:
       #
-      # aliases = Aliases.new('read' => 'read:users')
-      # aliases.expand('read') # => Scopes['read', 'read:users']
+      # aliases = Aliases.new('read' => 'read.users')
+      # aliases.expand('read') # => Scopes['read', 'read.users']
       #
       # @param [Array<String>] scopes
       # @return [Scopes]

--- a/lib/bridger/scopes/aliases.rb
+++ b/lib/bridger/scopes/aliases.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Bridger
+  class Scopes
+    # Aliases for scopes
+    # Example:
+    #  aliases = Aliases.new('read' => ['read:users'])
+    #  aliases.map('read') # => ['read:users']
+    #  aliases.map('read:users') # => ['read:users']
+    class Aliases
+      # @param [Hash<String, Array<String>>] scope mapping
+      def initialize(mapping = {})
+        @mapping = mapping
+      end
+
+      # Map scopes to aliases
+      # Example:
+      # aliases = Aliases.new('read' => ['read:users'])
+      # aliases.map('read') # => ['read:users']
+      #
+      # @param [Array<String>] scopes
+      # @return [Scopes]
+      def map(scopes)
+        scpes = Array(scopes.to_a).reduce([]){|memo, sc|
+          memo + Array(@mapping.fetch(sc, sc))
+        }.uniq
+
+        Scopes.wrap(scpes)
+      end
+
+      # Expand scopes with aliases, including original scopes
+      # Example:
+      #
+      # aliases = Aliases.new('read' => 'read:users')
+      # aliases.expand('read') # => Scopes['read', 'read:users']
+      #
+      # @param [Array<String>] scopes
+      # @return [Scopes]
+      def expand(scopes)
+        scopes = Array(scopes.to_a)
+        registered_scopes = scopes.filter { |sc| @mapping.key?(sc) }
+        result = registered_scopes + registered_scopes.reduce([]) { |memo, sc|
+          memo + Array(@mapping.fetch(sc))
+        }.uniq
+
+        Scopes.wrap(result)
+      end
+    end
+  end
+end

--- a/lib/bridger/scopes/aliases.rb
+++ b/lib/bridger/scopes/aliases.rb
@@ -8,9 +8,11 @@ module Bridger
     #  aliases.map('read') # => ['read.users']
     #  aliases.map('read:users') # => ['read.users']
     class Aliases
-      # @param [Hash<String, Array<String>>] scope mapping
+      # @param [Hash<#to_s, Array<#to_s>>] scope mapping
       def initialize(mapping = {})
-        @mapping = mapping
+        @mapping = mapping.each.with_object({}) { |(k, v), memo|
+          memo[k.to_s] = Array(v).map(&:to_s)
+        }
       end
 
       # Map scopes to aliases

--- a/lib/bridger/scopes/scope.rb
+++ b/lib/bridger/scopes/scope.rb
@@ -12,6 +12,10 @@ module Bridger
         @segments = sc.is_a?(Array) ? sc : sc.split(SEP)
       end
 
+      def to_scope
+        self
+      end
+
       def to_s
         segments.join(SEP)
       end

--- a/lib/bridger/scopes/scope.rb
+++ b/lib/bridger/scopes/scope.rb
@@ -3,8 +3,8 @@
 module Bridger
   class Scopes
     class Scope
-      SEP = '.'.freeze
-      WILDCARD = '*'.freeze
+      SEP = '.'
+      WILDCARD = '*'
 
       include Comparable
 

--- a/lib/bridger/scopes/scope.rb
+++ b/lib/bridger/scopes/scope.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Bridger
+  class Scopes
+    class Scope
+      SEP = '.'.freeze
+      WILDCARD = '*'.freeze
+
+      include Comparable
+
+      def initialize(sc)
+        @segments = sc.is_a?(Array) ? sc : sc.split(SEP)
+      end
+
+      def to_s
+        segments.join(SEP)
+      end
+
+      def to_a
+        segments.dup
+      end
+
+      def can?(another_scope)
+        self >= another_scope
+      end
+
+      def <=>(another_scope)
+        a, b = segments, another_scope.segments
+        return -1 if a.size > b.size
+
+        a = equalize(a, b)
+        b = equalize(b, a)
+        diff = a - b
+        diff.size == 0 ? 1 : -1
+      end
+
+      protected
+
+      attr_reader :segments
+
+      private
+
+      def equalize(a, b)
+        shortest = [a.size, b.size].min
+        0.upto(shortest - 1).map { |i| a[i] == WILDCARD ? b[i] : a[i] }
+      end
+    end
+  end
+end

--- a/lib/bridger/scopes/scope.rb
+++ b/lib/bridger/scopes/scope.rb
@@ -8,8 +8,27 @@ module Bridger
 
       include Comparable
 
-      def initialize(sc)
-        @segments = sc.is_a?(Array) ? sc : sc.split(SEP)
+      def self.wrap(sc)
+        case sc
+          in Scope
+            sc
+          in Array => list if list.all?{|s| s.is_a?(String) }
+            new(sc)
+          in String
+            new(sc.split(SEP))
+          in Symbol
+            new([sc.to_s])
+          else
+            if sc.respond_to?(:to_scope)
+              sc.to_scope
+            else
+              raise ArgumentError, "Can't turn #{sc.inspect} into a Scope"
+            end
+        end
+      end
+
+      def initialize(segments)
+        @segments = segments
       end
 
       def to_scope

--- a/lib/bridger/scopes/tree.rb
+++ b/lib/bridger/scopes/tree.rb
@@ -115,6 +115,10 @@ module Bridger
           self
         end
 
+        def respond_to?(method_name, include_private = false)
+          method_name == :to_scope ? true : super
+        end
+
         def *
           node = Node.new(::Bridger::Scopes::Scope::WILDCARD, self)
           shared_grandchildren.each do |child|

--- a/lib/bridger/scopes/tree.rb
+++ b/lib/bridger/scopes/tree.rb
@@ -123,6 +123,11 @@ module Bridger
           self
         end
 
+        # Hash equality to make Nodes work with Aliases.
+        def hash
+          to_s.hash
+        end
+
         # Wildcard node.
         # @return [Node]
         def *

--- a/lib/bridger/scopes/tree.rb
+++ b/lib/bridger/scopes/tree.rb
@@ -107,7 +107,7 @@ module Bridger
       # Ex. node.api.products.own.read
       #
       class Node < BasicObject
-        attr_reader :__segment, :__children, :to_s
+        attr_reader :__segment, :__children, :to_s, :to_a
 
         # @param segment [String] the name of the node
         # @param parent [Node] the parent node
@@ -115,6 +115,7 @@ module Bridger
           @__segment = segment.to_s
           @__parent = parent
           @__children = {}
+          @to_a = @__parent ? @__parent.to_a + [@__segment] : [@__segment]
           @to_s = [@__parent, @__segment].compact.map(&:to_s).join('.')
         end
 
@@ -155,7 +156,7 @@ module Bridger
         # by endpoints.
         # @return [Scope]
         def to_scope
-          ::Bridger::Scopes::Scope.new(to_s)
+          ::Bridger::Scopes::Scope.new(to_a)
         end
 
         # Add a child node and define a method to access it.

--- a/lib/bridger/scopes/tree.rb
+++ b/lib/bridger/scopes/tree.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'bridger/scopes/scope'
+
+module Bridger
+  class Scopes
+    class Tree
+      ROOT_SEGMENT = 'root'
+
+      def initialize(root_segment = ROOT_SEGMENT, &config)
+        recorder = Recorder.new(root_segment)
+        config.call(recorder) if block_given?
+        @root = build_tree(recorder)
+        define_singleton_method(root_segment) { @root }
+        freeze
+      end
+
+      private
+
+      def build_tree(recorder, parent = nil)
+        node = Node.new(recorder.__segment, parent)
+        recorder.__children.values.each do |child_recorder|
+          node.add_child(build_tree(child_recorder, node))
+        end
+        node.freeze
+      end
+
+      class Node < BasicObject
+        attr_reader :__segment, :__children, :to_s
+
+        def initialize(segment, parent = nil)
+          @__segment = segment.to_s
+          @__parent = parent
+          @__children = {}
+          @to_s = [@__parent, @__segment].compact.map(&:to_s).join('.')
+        end
+
+        def freeze
+          @__children.freeze
+          self
+        end
+
+        def *
+          node = Node.new(::Bridger::Scopes::Scope::WILDCARD, self)
+          @__children.values.each do |child|
+            child.__children.values.each do |grandchild|
+              node.add_child(grandchild.with_parent(node))
+            end
+          end
+          node.freeze
+        end
+
+        def with_parent(parent)
+          Node.new(@__segment, parent)
+        end
+
+        def to_scope
+          ::Bridger::Scopes::Scope.new(to_s)
+        end
+
+        def add_child(node)
+          @__children[node.__segment] = node
+          instance_eval <<-RUBY, __FILE__, __LINE__ + 1
+            def #{node.__segment}
+              @__children['#{node.__segment}']
+            end
+          RUBY
+        end
+      end
+
+      class Recorder < BasicObject
+        attr_reader :__segment, :__children
+
+        def initialize(segment)
+          @__segment = segment
+          @__children = {}
+        end
+
+        def method_missing(method_name, *args, &block)
+          @__children[method_name] ||= Recorder.new(method_name)
+        end
+
+        def respond_to_missing?(method_name, include_private = false)
+          true
+        end
+      end
+    end
+  end
+end

--- a/lib/bridger/scopes/tree.rb
+++ b/lib/bridger/scopes/tree.rb
@@ -29,7 +29,7 @@ module Bridger
     #  ...
     #  )
     #
-    # Hierarchies can also be defined using the [] operator:
+    # Hierarchies can also be defined using the > operator:
     # This can help avoid typos.
     #
     #  SCOPES = Bridger::Scopes::Tree.new('bootic') do |bootic|
@@ -40,9 +40,9 @@ module Bridger
     #    all = 'all'
     #    read = 'read'
     #
-    #    bootic[api, products, own, read]
-    #    bootic[api, products, all, read]
-    #    bootic[api, orders, own, read]
+    #    bootic > api > products > own > read
+    #    bootic > api > products > all > read
+    #    bootic > api > orders > own > read
     #  end
     class Tree
       ROOT_SEGMENT = 'root'
@@ -116,10 +116,8 @@ module Bridger
           @__children = {}
         end
 
-        def [](*segments)
-          segments.reduce(self) do |node, segment|
-            node.__register(segment.to_sym)
-          end
+        def >(segment)
+          __register(segment)
         end
 
         def __register(child_name)

--- a/spec/authorizers_spec.rb
+++ b/spec/authorizers_spec.rb
@@ -38,13 +38,14 @@ RSpec.describe Bridger::Authorizers do
     expect(TREE.authorized?("btc.account.shops.mine.show", auth, {shop_id: 10})).to be false
 
     tree = Bridger::Authorizers::Tree.new
-    tree.at("btc.account") do |auth, params|
+    tree.at(Bridger::Scopes::Scope.wrap('btc.account')) do |auth, params|
       false
     end
 
     expect(tree.authorized?("btc", auth, params)).to be true
-    expect(tree.authorized?("btc.foo", auth, params)).to be true
+    expect(tree.authorized?(Bridger::Scopes::Scope.wrap('btc.foo'), auth, params)).to be true
     expect(tree.authorized?("btc.account", auth, params)).to be false
     expect(tree.authorized?("btc.account.shops", auth, params)).to be false
+    expect(tree.authorized?("btc.account.foo", auth, params)).to be false
   end
 end

--- a/spec/endpoint_spec.rb
+++ b/spec/endpoint_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Bridger::Endpoint do
   it 'it accepts #to_scope interface' do
     scope_class = Data.define(:scope) do
       def to_scope
-        Bridger::Scopes::Scope.new(scope)
+        Bridger::Scopes::Scope.wrap(scope)
       end
     end
 

--- a/spec/endpoint_spec.rb
+++ b/spec/endpoint_spec.rb
@@ -48,6 +48,26 @@ RSpec.describe Bridger::Endpoint do
     expect(endpoint.serializer).to eq serializer
   end
 
+  it 'it accepts #to_scope interface' do
+    scope_class = Data.define(:scope) do
+      def to_scope
+        Bridger::Scopes::Scope.new(scope)
+      end
+    end
+
+    endpoint = described_class.new(
+      name: 'create_product',
+      verb: :post,
+      path: '/v1/products',
+      title: 'Create products',
+      scope: scope_class.new(scope: 'a.b.c'),
+      authorizer: authorizer,
+      action: action,
+    )
+
+    expect(endpoint.scope.to_s).to eq 'a.b.c'
+  end
+
   describe '#run' do
     let(:auth) { double('Auth', authorize!: true) }
     let(:presenter) { double('Presenter') }

--- a/spec/scopes/tree_spec.rb
+++ b/spec/scopes/tree_spec.rb
@@ -28,6 +28,22 @@ RSpec.describe Bridger::Scopes::Tree do
     expect(scope.to_s).to eq('bootic.api.products.*.read')
   end
 
+  specify '* allows intersection of possible children' do
+    tree = described_class.new('bootic') do |bootic|
+      bootic.api.products.own.read
+      bootic.api.products.own.delete
+      bootic.api.products.all.read
+      bootic.api.orders.own.read
+    end
+
+    # Wildcard nodes support the intersection of child nodes
+    # In this case, bootic.api.products.own and bootic.api.products.all support read,
+    # but only bootic.api.products.own supports delete
+    expect {
+      tree.bootic.api.products.*.delete
+    }.to raise_error(NoMethodError)
+  end
+
   specify 'defining unique segments at the top' do
     tree = described_class.new('bootic') do |bootic|
       api = 'api'

--- a/spec/scopes/tree_spec.rb
+++ b/spec/scopes/tree_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe Bridger::Scopes::Tree do
       all = 'all'
       read = 'read'
 
-      bootic[api, products, own, read]
-      bootic[api, products, all, read]
-      bootic[api, orders, own, read]
+      bootic > api > products > own > read
+      bootic > api > products > all > read
+      bootic > api > orders > own > read
     end
 
     expect(tree.bootic.api.products.own.read.to_s).to eq('bootic.api.products.own.read')

--- a/spec/scopes/tree_spec.rb
+++ b/spec/scopes/tree_spec.rb
@@ -45,4 +45,42 @@ RSpec.describe Bridger::Scopes::Tree do
     expect(tree.bootic.api.products.own.read.to_s).to eq('bootic.api.products.own.read')
     expect(tree.bootic.api.products.*.read.to_s).to eq('bootic.api.products.*.read')
   end
+
+  specify 'block notation with node argument' do
+    tree = described_class.new('bootic') do |bootic|
+      bootic.api.products do |n|
+        n.own do |n|
+          n.read
+          n.write
+          n > 'list'
+        end
+
+        n.all.read
+      end
+    end
+
+    expect(tree.bootic.api.products.own.read.to_s).to eq('bootic.api.products.own.read')
+    expect(tree.bootic.api.products.own.write.to_s).to eq('bootic.api.products.own.write')
+    expect(tree.bootic.api.products.own.list.to_s).to eq('bootic.api.products.own.list')
+    expect(tree.bootic.api.products.own.to_s).to eq('bootic.api.products.own')
+    expect(tree.bootic.api.products.all.read.to_s).to eq('bootic.api.products.all.read')
+  end
+
+  specify 'block notation without node argument' do
+    tree = described_class.new('bootic') do
+      api.products do
+        own do
+          read
+          write
+        end
+
+        all.read
+      end
+    end
+
+    expect(tree.bootic.api.products.own.read.to_s).to eq('bootic.api.products.own.read')
+    expect(tree.bootic.api.products.own.write.to_s).to eq('bootic.api.products.own.write')
+    expect(tree.bootic.api.products.own.to_s).to eq('bootic.api.products.own')
+    expect(tree.bootic.api.products.all.read.to_s).to eq('bootic.api.products.all.read')
+  end
 end

--- a/spec/scopes/tree_spec.rb
+++ b/spec/scopes/tree_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Bridger::Scopes::Tree do
     expect(tree.bootic.api.products.own.to_s).to eq('bootic.api.products.own')
     expect(tree.bootic.api.products.to_s).to eq('bootic.api.products')
     expect(tree.bootic.api.products.*.read.to_s).to eq('bootic.api.products.*.read')
+    expect(tree.bootic.api.products.*.read.to_a).to eq(%w[bootic api products * read])
     expect {
       tree.bootic.foo.products
     }.to raise_error(NoMethodError)

--- a/spec/scopes/tree_spec.rb
+++ b/spec/scopes/tree_spec.rb
@@ -27,4 +27,22 @@ RSpec.describe Bridger::Scopes::Tree do
     expect(scope).to be_a(Bridger::Scopes::Scope)
     expect(scope.to_s).to eq('bootic.api.products.*.read')
   end
+
+  specify 'defining unique segments at the top' do
+    tree = described_class.new('bootic') do |bootic|
+      api = 'api'
+      products = 'products'
+      orders = 'orders'
+      own = 'own'
+      all = 'all'
+      read = 'read'
+
+      bootic[api, products, own, read]
+      bootic[api, products, all, read]
+      bootic[api, orders, own, read]
+    end
+
+    expect(tree.bootic.api.products.own.read.to_s).to eq('bootic.api.products.own.read')
+    expect(tree.bootic.api.products.*.read.to_s).to eq('bootic.api.products.*.read')
+  end
 end

--- a/spec/scopes/tree_spec.rb
+++ b/spec/scopes/tree_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require 'bridger/scopes/tree'
+
+RSpec.describe Bridger::Scopes::Tree do
+  specify 'declaring and accessing allowed scope hierarchies' do
+    tree = described_class.new('bootic') do |bootic|
+      bootic.api.products.own.read
+      bootic.api.products.all.read
+      bootic.api.orders.own.read
+    end
+
+    expect(tree.bootic.api.products.own.read.to_s).to eq('bootic.api.products.own.read')
+    expect(tree.bootic.api.products.own.to_s).to eq('bootic.api.products.own')
+    expect(tree.bootic.api.products.to_s).to eq('bootic.api.products')
+    expect(tree.bootic.api.products.*.read.to_s).to eq('bootic.api.products.*.read')
+    expect {
+      tree.bootic.foo.products
+    }.to raise_error(NoMethodError)
+
+    expect {
+      tree.bootic.api.products.*.api
+    }.to raise_error(NoMethodError)
+
+    scope = tree.bootic.api.products.*.read.to_scope
+    expect(scope).to be_a(Bridger::Scopes::Scope)
+    expect(scope.to_s).to eq('bootic.api.products.*.read')
+  end
+end

--- a/spec/scopes_spec.rb
+++ b/spec/scopes_spec.rb
@@ -45,6 +45,16 @@ RSpec.describe Bridger::Scopes do
       expect(scopes).to be_a(Bridger::Scopes)
       expect(scopes).to match_array %w[btc.me btc.account.shops.mine btc.foo.bar]
     end
+
+    it 'expands aliases preserving original scopes' do
+      aliases = described_class.new(
+        'admin' => %w[btc.me btc.account.shops.mine],
+        'public' => %w[btc.me btc.shops.list.public]
+      )
+
+      scopes = aliases.expand(%w[admin btc.foo.bar])
+      expect(scopes.to_a).to match_array %w[admin btc.me btc.account.shops.mine]
+      expect(aliases.expand(%w[nope]).any?).to be(false)
     end
   end
 
@@ -78,6 +88,7 @@ RSpec.describe Bridger::Scopes do
 
       expect(user_scopes.can?(required_scopes)).to be true
       expect(required_scopes.can?(user_scopes)).to be false
+      expect(user_scopes.can?('btc.account.assets.mine.create')).to be true
 
       user_scopes = described_class.new(["admin"])
       required_scopes = described_class.new(["btc.me", "admin"])

--- a/spec/scopes_spec.rb
+++ b/spec/scopes_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe Bridger::Scopes do
 
   it "compares" do
     expect(described_class.wrap(['api']) > described_class.wrap(['api.me'])).to be true
+    expect(described_class.wrap(:api) > described_class.wrap(['api.me'])).to be true
     expect(described_class.wrap(['foo', 'api']) > described_class.wrap(['api.me'])).to be true
     expect(described_class.wrap(['foo', 'api']) > described_class.wrap(['api', 'api.me'])).to be true
     expect(described_class.wrap(['api.users']) > described_class.wrap(['api', 'api.me'])).to be false

--- a/spec/scopes_spec.rb
+++ b/spec/scopes_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Bridger::Scopes do
   private
 
   def scope(exp)
-    described_class.new(exp)
+    described_class.wrap(exp)
   end
 
   def first_one_wins(exp1, exp2)

--- a/spec/scopes_spec.rb
+++ b/spec/scopes_spec.rb
@@ -56,6 +56,26 @@ RSpec.describe Bridger::Scopes do
       expect(scopes.to_a).to match_array %w[admin btc.me btc.account.shops.mine]
       expect(aliases.expand(%w[nope]).any?).to be(false)
     end
+
+    it 'works with scope trees' do
+      scopes = Bridger::Scopes::Tree.new('api') do
+        admin
+        me
+        products do
+          read
+          write
+        end
+      end
+
+      aliases = described_class.new(
+        scopes.api.admin => [scopes.api.me, scopes.api.products],
+        'guest' => [scopes.api.me]
+      )
+
+      expect(aliases.map(%w[api.admin])).to match_array %w[api.me api.products]
+      expect(aliases.map(%w[guest])).to match_array %w[api.me]
+      expect(aliases.map(%w[api.me])).to match_array %w[api.me]
+    end
   end
 
   it "compares" do

--- a/spec/scopes_spec.rb
+++ b/spec/scopes_spec.rb
@@ -35,14 +35,16 @@ RSpec.describe Bridger::Scopes do
   end
 
   describe Bridger::Scopes::Aliases do
-    it "maps aliases" do
+    it 'maps aliases' do
       aliases = described_class.new(
-        "admin" => ["btc.me", "btc.account.shops.mine"],
-        "public" => ["btc.me", "btc.shops.list.public"]
+        'admin' => %w[btc.me btc.account.shops.mine],
+        'public' => %w[btc.me btc.shops.list.public]
       )
 
-      scopes = aliases.map(["admin", "btc.foo.bar"])
-      expect(scopes).to match_array ["btc.me", "btc.account.shops.mine", "btc.foo.bar"]
+      scopes = aliases.map(%w[admin btc.foo.bar])
+      expect(scopes).to be_a(Bridger::Scopes)
+      expect(scopes).to match_array %w[btc.me btc.account.shops.mine btc.foo.bar]
+    end
     end
   end
 

--- a/spec/support/test_service.rb
+++ b/spec/support/test_service.rb
@@ -160,45 +160,54 @@ Bridger::Auth.config do |c|
   c.token_store = TOKEN_STORE
 end
 
+SCOPES = Bridger::Scopes::Tree.new('api') do
+  me
+  users do
+    list
+    create
+    delete
+  end
+end
+
 # Your API's endpoints. Each combines an action, serializer, some metadata and a permissions scope.
 Bridger::Service.instance.build do
   endpoint(:root, :get, "/",
     title: "API root",
-    scope: "api.me",
+    scope: SCOPES.api.me,
     serializer: RootSerializer,
   )
 
   endpoint(:users, :get, "/users",
     title: "List users",
-    scope: "api.users.list",
+    scope: SCOPES.api.users.list,
     action: ListUsers,
     serializer: UsersSerializer,
   )
 
   endpoint(:user, :get, "/users/:user_id",
     title: "User details",
-    scope: "api.users.list",
+    scope: SCOPES.api.users.list,
     action: ShowUser,
     serializer: UserSerializer,
   )
 
   endpoint(:user_things, :get, "/users/:user_id/things",
     title: "User things",
-    scope: "api.users.list",
+    scope: SCOPES.api.users.list,
     action: ListUserThings,
     serializer: UserThingsSerializer,
   )
 
   endpoint(:create_user, :post, "/users",
     title: "Create a new user",
-    scope: "api.users.create",
+    scope: SCOPES.api.users.create,
     action: CreateUser,
     serializer: UserSerializer,
   )
 
   endpoint(:delete_user, :delete, "/users/:user_id",
     title: "Delete user",
-    scope: "api.users.delete",
+    scope: SCOPES.api.users.delete,
     action: DeleteUser,
     serializer: nil,
   )


### PR DESCRIPTION
## Pre-defined scope trees

Defining scopes as strings can be error prone (easy to make typos or get the hierarchy wrong!).

The `Bridger::Scopes::Tree` utility can be helpful to define all possible scope hierarchies in a single place.

```ruby
SCOPES = Bridger::Scopes::Tree.new('all') do |all|
  all.users.update
  all.users.read
  all.users.create
  all.orders.read
end
```

This constant can now be used to resolve allowed scope hierarchies when configuring endpoints:

```ruby
endpoint(:update_user, :put, '/users/:user_id',
  title: "Update a user",
  scope: SCOPES.all.users.update, # <= this will raise if this scope is not defined.
  action: UpdateUser,
  serializer: UserSerializer
)
```

The scope tree will expose all defined hierarchies

```ruby
SCOPES.all.users # 'all.users'
SCOPES.all.users.create # 'all.users.create'
```

... But not invalid hierarchies.

```ruby
SCOPES.all.users.orders # raises NoMethodError
```

Wilcards work too

```ruby
SCOPES.all.*.read # 'all.*.read`
```

Note that wildcards only allow sub-scopes that are shared by all children.

```ruby
SCOPES.all.*.read # Ok
SCOPES.all.*.update # raises NoMethodError because not all children of `all.*` support `update`
```

Hierarchies can also be defined using the > operator:
This can help avoid typos.

```ruby
SCOPES = Bridger::Scopes::Tree.new('bootic') do |bootic|
  api = 'api'
  products = 'products'
  orders = 'orders'
  own = 'own'
  all = 'all'
  read = 'read'

  bootic > api > products > own > read
  bootic > api > products > all > read
  bootic > api > orders > own > read
end
```

Block notation can be used where it makes sense:

```ruby
SCOPES = Bridger::Scopes::Tree.new('bootic') do |bootic|
  bootic.api.products do |n|
    n.own do |n|
      n.read
      n.write
      n > 'list' # use `>` to append variables or constants
    end
  end
end
```

Block notation also works without explicit node argument (but can't access outer variables):

```ruby
SCOPES = Bridger::Scopes::Tree.new('bootic') do
  api.products do
    own do
      read
      write
    end
    all do
      read
    end
  end
end
```

Scope trees also work with scope aliases.

```ruby
config.aliases = {
  'admin' => [SCOPES.api.products.own, SCOPES.api.orders.own, SCOPES.api.all.read],
  'god' => [SCOPES.api]
}
```

## Other changes

### `Bridger::Scopes::Aliases#map`

Map scopes to aliases

```ruby
aliases = Bridger::Scopes::Aliases.new('read' => ['read:users'])
aliases.map('read') # => Bridger::Scopes(['read:users'])
```

### `Bridger::Scopes::Aliases#expand`

Like `#map`, but includes mapped scope in resulting list.

```ruby
aliases.expand('read') # => Bridger::Scopes(['read', 'read:users'])
```

### `Bridger::Scopes.wrap` with a Symbol

```ruby
Bridger::Scopes.wrap(:read) # => Bridger::Scopes(['read'])
```

### `Bridger::Scopes::Scope.wrap`

```ruby
Bridger::Scopes::Scope.wrap('a.b.c') # => Bridger::Scopes::Scope
Bridger::Scopes::Scope.wrap(['a', 'b', 'c']) # => Bridger::Scopes::Scope
Bridger::Scopes::Scope.wrap(Scope) # => Bridger::Scopes::Scope
```
