### PR TITLE
Scope trees

### DIFF
--- a/lib/bridger/scopes.rb
+++ b/lib/bridger/scopes.rb
@@ -49,6 +49,11 @@ module Bridger
       %(<#{self.class.name}##{object_id} [#{to_s}]>)
     end
 
+    def expand(attrs = {})
+      scp = scopes.map { |s| s.expand(attrs) }
+      self.class.new(scp)
+    end
+
     def to_s
       @to_s ||= scopes.join(', ')
     end

--- a/lib/bridger/scopes.rb
+++ b/lib/bridger/scopes.rb
@@ -21,24 +21,35 @@ module Bridger
       @scopes = [scopes].flatten.map { |s| Scope.wrap(s) }.sort{ |a, b| b <=> a}
     end
 
+    # Find first, most generic scope that matches given scope
+    #
+    # @param scope [Scope, String]
+    # @return [Scope, nil]
     def resolve(scope)
       sc = Scope.wrap(scope)
       scopes.find { |s| s >= sc }
     end
 
+    # @return [Boolean]
     def any?(&block)
       scopes.any? &block
     end
 
+    # @return [Boolean]
     def all?(&block)
       scopes.all? &block
     end
 
+    # @param another [Scopes, Scope, Array<Scope>]
+    # @return [Boolean]
     def can?(another)
       another = self.class.wrap(another)
       !!scopes.find{|s1| another.any?{|s2| s1 >= s2}}
     end
 
+    # Scope comparison. Implements Comparable
+    # @param another [Scopes, Scope, Array<Scope>]
+    # @return [Integer]
     def <=>(another)
       another = self.class.wrap(another)
       hit = scopes.find{|s1| another.all?{|s2| s1 >= s2}}
@@ -49,6 +60,14 @@ module Bridger
       %(<#{self.class.name}##{object_id} [#{to_s}]>)
     end
 
+    # Return a new [Scopes] with expanded scopes
+    #
+    # @example
+    #   scopes = Scopes.new(['accounts.my-account', 'shops.my-shop'])
+    #   scopes.expand('my-account' => 1, 'my-shop' => 2) # => Scopes.new(['accounts.1', 'shops.2'])
+    #
+    # @param attrs [Hash]
+    # @return [Scopes]
     def expand(attrs = {})
       scp = scopes.map { |s| s.expand(attrs) }
       self.class.new(scp)

--- a/lib/bridger/scopes/scope.rb
+++ b/lib/bridger/scopes/scope.rb
@@ -2,6 +2,29 @@
 
 module Bridger
   class Scopes
+    # Scopes define hierarchical permissions
+    # They are used to define access to resources
+    # A scope is a list of segments, e.g. 'foo.bar.baz'
+    # It can be initialized with a string, an array of strings, or a symbol
+    # It can also be initialized with another scope
+    # It can be expanded with a hash of values
+    # It can be compared with another scope
+    # It can be converted to a string
+    # It can be converted to an array of strings
+    # Example:
+    #
+    #  access_scope = Scope.wrap('root.accounts.*')
+    #  endpoint_scope = Scope.wrap('root.accounts.my_account.users.*')
+    #  access_scope >= endpoint_scope) # => true
+    #  access_scope < endpoint_scope) # => false
+    #
+    # Scopes can be "expanded" on request-time to have one or more segments replaced with values.
+    # This is useful for defining access to resources that are not known at the time of defining the scope.
+    #
+    # Example:
+    #  access_scope = Scope.wrap('root.accounts.my_account.users.*')
+    #  scope = access_scope.expand('my_account' => current_user.account_id) # => Scope('root.accounts.123.users.*')
+    #
     class Scope
       SEP = '.'
       WILDCARD = '*'
@@ -42,14 +65,6 @@ module Bridger
         end
       end
 
-      # A scope is a list of segments, e.g. 'foo.bar.baz'
-      # It can be initialized with a string, an array of strings, or a symbol
-      # It can also be initialized with another scope
-      # It can be expanded with a hash of values
-      # It can be compared with another scope
-      # It can be converted to a string
-      # It can be converted to an array of strings
-      #
       # @param [String, Array<String>, Symbol, Scope] sc
       # @return [Scope]
       def self.wrap(sc)

--- a/lib/bridger/scopes/scope.rb
+++ b/lib/bridger/scopes/scope.rb
@@ -5,14 +5,48 @@ module Bridger
     class Scope
       SEP = '.'
       WILDCARD = '*'
+      TEMPLATE_EXPR = /<(.+)>$/
+      ARRAY_EXPR = /\((.+)\)$/ # '(1,2,3)'
+      COMMA = ','
+      COLON = ':'
 
       include Comparable
+
+      Segment = Data.define(:name, :values) do
+        # 'foo'
+        # '(1,2,3)'
+        # '*'
+        def self.wrap(name)
+          return name if name.is_a?(self)
+
+          if name.is_a?(Array)
+            new("(#{name.join(COMMA)})", name.map(&:to_s))
+          elsif name.to_s =~ ARRAY_EXPR
+            new(name, $1.split(COMMA))
+          elsif name == WILDCARD
+            new(name, [])
+          else
+            new(name, [name.to_s])
+          end
+        end
+
+        def ==(other)
+          return true if name == WILDCARD || other.name == WILDCARD
+
+          # [1,2,3] >= [1]
+          (values & other.values).any?
+        end
+
+        def to_s
+          name
+        end
+      end
 
       def self.wrap(sc)
         case sc
           in Scope
             sc
-          in Array => list if list.all?{|s| s.is_a?(String) }
+          in Array => list
             new(sc)
           in String
             new(sc.split(SEP))
@@ -28,19 +62,35 @@ module Bridger
       end
 
       def initialize(segments)
-        @segments = segments
+        @segments = segments.map { |v| Segment.wrap(v) }
       end
 
       def to_scope
         self
       end
 
+      def expand(attrs = {})
+        segments = self.segments.map do |segment|
+          if value = attrs[segment.to_s]
+            Segment.wrap(value)
+          else
+            segment
+          end
+        end
+
+        self.class.new(segments)
+      end
+
+      def inspect
+        %(<#{self.class.name}##{object_id} [#{to_s}]>)
+      end
+
       def to_s
-        segments.join(SEP)
+        to_a.join(SEP)
       end
 
       def to_a
-        segments.dup
+        segments.map(&:to_s)
       end
 
       def can?(another_scope)
@@ -51,22 +101,15 @@ module Bridger
         a, b = segments, another_scope.segments
         return -1 if a.size > b.size
 
-        a = equalize(a, b)
-        b = equalize(b, a)
-        diff = a - b
-        diff.size == 0 ? 1 : -1
+        all_match = a.each_with_index.all? { |segment, i| segment == b[i] }
+        return -1 unless all_match
+
+        a.size < b.size ? 1 : 0
       end
 
       protected
 
       attr_reader :segments
-
-      private
-
-      def equalize(a, b)
-        shortest = [a.size, b.size].min
-        0.upto(shortest - 1).map { |i| a[i] == WILDCARD ? b[i] : a[i] }
-      end
     end
   end
 end

--- a/lib/bridger/scopes/scope.rb
+++ b/lib/bridger/scopes/scope.rb
@@ -5,7 +5,6 @@ module Bridger
     class Scope
       SEP = '.'
       WILDCARD = '*'
-      TEMPLATE_EXPR = /<(.+)>$/
       ARRAY_EXPR = /\((.+)\)$/ # '(1,2,3)'
       COMMA = ','
       COLON = ':'

--- a/lib/bridger/scopes/tree.rb
+++ b/lib/bridger/scopes/tree.rb
@@ -16,7 +16,7 @@ module Bridger
     #  SCOPES.bootic.api.products.own.read.to_s # => 'bootic.api.products.own.read'
     #  SCOPES.bootic.api.products.own.to_s # => 'bootic.api.products.own'
     #  SCOPES.bootic.api.*.read.to_s # => 'bootic.api.*.read'
-    #  SCOPES.bootic.foo.products # => NoMethodError
+    #  SCOPES.bootic.foo.products # => raises Bridger::Scopes::Scope::InvalidScopHierarchyError
     #
     # It can be used to define allowed scopes for an endpoint:
     #
@@ -78,7 +78,7 @@ module Bridger
     #   end
     #
     # `_any` takes an optional list of allowed values, in which case it has "any of" semantics.
-    # Values are matched with `#====` operator, so they can be regular expressions.
+    # Values are matched with `#===` operator, so they can be regular expressions.
     # If no values are given, `_any` has "anything" semantics.
     # `_any` can be used to define a catch-all scope:
     #

--- a/lib/bridger/scopes/tree.rb
+++ b/lib/bridger/scopes/tree.rb
@@ -71,6 +71,33 @@ module Bridger
     #     end
     #   end
     #
+    # Use `_any` to define segments that can be anything:
+    #
+    #   SCOPES = Bridger::Scopes::Tree.new('bootic') do |bootic|
+    #     bootic.api.products._any.read
+    #   end
+    #
+    # `_any` takes an optional list of allowed values, in which case it has "any of" semantics.
+    # Values are matched with `#====` operator, so they can be regular expressions.
+    # If no values are given, `_any` has "anything" semantics.
+    # `_any` can be used to define a catch-all scope:
+    #
+    #    SCOPES = Bridger::Scopes::Tree.new('bootic') do |bootic|
+    #      bootic.api do |s|
+    #        s.products do |s|
+    #          s._any('my_products', /^\d+$/) do |s| # matches 'my_products' or any number-like string
+    #            s.read
+    #          end
+    #       end
+    #     end
+    #
+    # With the above, the following scopes are allowed, using parenthesis notation to allow numbers and multiple values
+    #
+    #    bootic.api.products.(123).read # 'bootic.api.products.123.read'
+    #    bootic.api.products.(1, 2, 3).read # 'bootic.api.products.(1,2,3).read'
+    #    bootic.api.products.('my_products').read # 'bootic.api.products.my_products.read'
+    #    bootic.api.products.my_products.read # works too
+    #
     class Tree
       ROOT_SEGMENT = 'root'
 

--- a/spec/scopes/tree_spec.rb
+++ b/spec/scopes/tree_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe Bridger::Scopes::Tree do
       bootic.api.orders.own.read
     end
 
+    expect(tree.bootic.respond_to?(:inspect)).to be(true)
+    expect(tree.bootic.respond_to?(:to_scope)).to be(true)
     expect(tree.bootic.api.products.own.read.to_s).to eq('bootic.api.products.own.read')
     expect(tree.bootic.api.products.own.to_s).to eq('bootic.api.products.own')
     expect(tree.bootic.api.products.to_s).to eq('bootic.api.products')
@@ -18,11 +20,11 @@ RSpec.describe Bridger::Scopes::Tree do
     expect(tree.bootic.api.products.*.read.to_a).to eq(%w[bootic api products * read])
     expect {
       tree.bootic.foo.products
-    }.to raise_error(NoMethodError)
+    }.to raise_error(Bridger::Scopes::Tree::InvalidScopeHierarchyError)
 
     expect {
       tree.bootic.api.products.*.api
-    }.to raise_error(NoMethodError)
+    }.to raise_error(Bridger::Scopes::Tree::InvalidScopeHierarchyError)
 
     scope = tree.bootic.api.products.*.read.to_scope
     expect(scope).to be_a(Bridger::Scopes::Scope)
@@ -42,7 +44,7 @@ RSpec.describe Bridger::Scopes::Tree do
     # but only bootic.api.products.own supports delete
     expect {
       tree.bootic.api.products.*.delete
-    }.to raise_error(NoMethodError)
+    }.to raise_error(Bridger::Scopes::Tree::InvalidScopeHierarchyError)
   end
 
   specify 'defining unique segments at the top' do
@@ -99,5 +101,91 @@ RSpec.describe Bridger::Scopes::Tree do
     expect(tree.bootic.api.products.own.write.to_s).to eq('bootic.api.products.own.write')
     expect(tree.bootic.api.products.own.to_s).to eq('bootic.api.products.own')
     expect(tree.bootic.api.products.all.read.to_s).to eq('bootic.api.products.all.read')
+  end
+
+  specify 'wildcards' do
+    tree = described_class.new('bootic') do
+      api do
+        products do
+          _any do
+            read
+            write
+          end
+        end
+      end
+    end
+
+    expect(tree.bootic.api.products.*.read.to_s).to eq('bootic.api.products.*.read')
+    expect(tree.bootic.api.products._value('111').read.to_s).to eq('bootic.api.products.111.read')
+    expect(tree.bootic.api.products._value([1, 2, 3]).read.to_s).to eq('bootic.api.products.(1,2,3).read')
+  end
+
+  specify do
+    tree = Bridger::Scopes::Tree.new('bootic') do |bootic|
+      integer = /^\d+$/
+
+      bootic.api do
+        accounts do
+          _any('resource_account', 'own_account', integer) do
+            shops do
+              resource_shops do
+                contacts do
+                  _any do
+                    read
+                  end
+                end
+
+                products do
+                  _any do
+                    read
+                  end
+                end
+
+                orders do
+                  _any(integer) do
+                    read
+                  end
+                end
+
+                settings do
+                  _any do
+                    update
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+
+    expect(tree.bootic.api.accounts.resource_account.shops.*.products.*.read.to_s).to eq('bootic.api.accounts.resource_account.shops.*.products.*.read')
+    expect(tree.bootic.api.accounts.('123').shops.*.products.*.read.to_s).to eq('bootic.api.accounts.123.shops.*.products.*.read')
+    expect(tree.bootic.api.accounts.own_account.shops.to_s).to eq('bootic.api.accounts.own_account.shops')
+    expect(tree.bootic.api.accounts.resource_account.shops.*.orders.('123').read.to_s).to eq('bootic.api.accounts.resource_account.shops.*.orders.123.read')
+    expect(tree.bootic.api.accounts.resource_account.shops.*.orders.(1,'2').read.to_s).to eq('bootic.api.accounts.resource_account.shops.*.orders.(1,2).read')
+    expect(tree.bootic.api.accounts.resource_account.shops.*.orders.([1,'2']).read.to_s).to eq('bootic.api.accounts.resource_account.shops.*.orders.(1,2).read')
+    expect(tree.bootic.api.accounts.*.shops.*.products.*.read.to_s).to eq('bootic.api.accounts.*.shops.*.products.*.read')
+
+    # Invalid scope hierarchy (settings.*.read is not available in tree)
+    expect {
+      tree.bootic.api.accounts.*.shops.*.settings.*.read
+    }.to raise_error(Bridger::Scopes::Tree::InvalidScopeHierarchyError)
+
+    # Free value with invalid format
+    expect {
+      tree.bootic.api.accounts.resource_account.shops.*.orders._value('nope').read.to_s
+    }.to raise_error(Bridger::Scopes::Tree::InvalidScopeHierarchyError)
+
+    # Free value where none is declared
+    expect {
+      tree.bootic.api.accounts.resource_account.shops._value('11').orders.*.read.to_s
+    }.to raise_error(Bridger::Scopes::Tree::InvalidScopeHierarchyError)
+
+    # Invalid value for _any constraints
+    expect {
+      tree.bootic.api.accounts.('nope').shops
+    }.to raise_error(Bridger::Scopes::Tree::InvalidScopeHierarchyError)
+    # expect(tree.to_h).to eq({})
   end
 end


### PR DESCRIPTION
Improvements to `Bridger::Scopes::Tree`

Use `_any` to define segments that can be anything:

```ruby
SCOPES = Bridger::Scopes::Tree.new('bootic') do |bootic|
  bootic.api.products._any.read
end
```

`_any` takes an optional list of allowed values, in which case it has "any of" semantics.
Values are matched with `#===` operator, so they can be regular expressions.
If no values are given, `_any` has "anything" semantics.
`_any` can be used to define a catch-all scope:

```ruby
SCOPES = Bridger::Scopes::Tree.new('bootic') do |bootic|
 bootic.api do |s|
   s.products do |s|
     s._any('my_products', /^\d+$/) do |s| # matches 'my_products' or any number-like string
       s.read
     end
  end
end
```

With the above, the following scopes are allowed, using parenthesis notation to allow numbers and multiple values

```ruby
bootic.api.products.(123).read # 'bootic.api.products.123.read'
bootic.api.products.(1, 2, 3).read # 'bootic.api.products.(1,2,3).read'
bootic.api.products.('my_products').read # 'bootic.api.products.my_products.read'
bootic.api.products.my_products.read # works too
```
